### PR TITLE
Release 1.0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Senkyoshi Canvas Plugin
 
-This plugin enables the use of the Senkyoshi converter inside of Canvas. It adds a blackboard cartridge option to the import content dropdown for a course.
+This plugin enables the use of the [Senkyoshi](https://github.com/atomicjolt/senkyoshi) converter inside of Canvas. It adds a blackboard cartridge option to the import content dropdown for a course.
 
 ## Installation
 

--- a/lib/senkyoshi_canvas_plugin/version.rb
+++ b/lib/senkyoshi_canvas_plugin/version.rb
@@ -14,5 +14,5 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 module SenkyoshiCanvasPlugin
-  VERSION = "1.0.1".freeze
+  VERSION = "1.0.8".freeze
 end

--- a/senkyoshi_canvas_plugin.gemspec
+++ b/senkyoshi_canvas_plugin.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails", ">= 3.2", "< 5.1"
   spec.add_dependency "canvas_cc"
-  spec.add_dependency "senkyoshi"
+  spec.add_dependency "senkyoshi", "1.0.8"
 end


### PR DESCRIPTION
From now on the Senkyoshi Canvas plugin will mirror the version of Senkyoshi.
Updates the readme.